### PR TITLE
 Create list page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,6 +5,7 @@ import ProtectedRoute from "./components/ProtectedRoute";
 import Home from "./pages/Home/Home";
 import PublicRoute from "./components/PublicRoute";
 import List from "./pages/List/List.tsx";
+import CreateList from "./pages/CreateList/CreateList.tsx";
 
 function App() {
   return (
@@ -36,14 +37,22 @@ function App() {
             </ProtectedRoute>
           }
         />
-          <Route
-            path="/list/:listId"
+        <Route
+            path="/create-list"
             element={
               <ProtectedRoute>
-                  <List />
+                <CreateList />
               </ProtectedRoute>
             }
-          />
+        />
+        <Route
+          path="/list/:listId"
+          element={
+            <ProtectedRoute>
+                <List />
+            </ProtectedRoute>
+          }
+        />
         {/*Handle unknown routes with 404 message*/}
         <Route path="*" element={<h2>404 Not Found</h2>} />
       </Routes>

--- a/client/src/components/List/CreateListTask.tsx
+++ b/client/src/components/List/CreateListTask.tsx
@@ -1,0 +1,81 @@
+import {useState} from "react";
+import styles from "./Task.module.scss";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {faPencil, faTrash, faCheck} from "@fortawesome/free-solid-svg-icons";
+
+interface TempTaskProps {
+  itemId: number;
+  name: string;
+  completed: boolean;
+  deleteTask: (taskId: number) => void;
+  toggleTask: (taskId: number) => void;
+}
+
+function CreateListTask(props: TempTaskProps) {
+
+  const [ editing, setEditing ] = useState(false);
+  const [ textInput, setTextInput ] = useState(props.name);
+  const [ isComplete, setIsComplete ] = useState(props.completed);
+  const [ name, setName ] = useState(props.name);
+
+  function toggleComplete() {
+    setIsComplete(isComplete => !isComplete)
+    props.toggleTask(props.itemId);
+  }
+
+  function handleSave() {
+    setName(textInput);
+    setEditing(false);
+  }
+
+  return (
+      <div key={props.itemId} className={styles.listItem}>
+        <input
+            type="checkbox"
+            checked={isComplete}
+            onChange={toggleComplete}
+            className={styles.checkBox}
+        />
+        {editing ? (
+            <>
+              <input
+                  value = {textInput}
+                  onChange={(e) => setTextInput(e.target.value)}
+                  className={styles.taskName}
+              />
+              <div className={styles.end}>
+                <button
+                    className={styles.saveButton + " " + styles.icon}
+                    onClick={handleSave}>
+                  <FontAwesomeIcon icon={faCheck}/>
+                </button>
+                <button
+                    className={styles.deleteButton + " " + styles.icon}
+                    onClick={() => props.deleteTask(props.itemId)}>
+                  <FontAwesomeIcon icon={faTrash} />
+                </button>
+              </div>
+            </>
+        ) : (
+            <>
+              <span className={(isComplete ? styles.completed : "") + " " + styles.taskName}>{name}</span>
+              <div className={styles.end}>
+                <button
+                    className={styles.editButton + " " + styles.icon}
+                    onClick={() => setEditing(true)}>
+                  <FontAwesomeIcon icon={faPencil}/>
+                </button>
+                <button
+                    className={styles.deleteButton + " " + styles.icon}
+                    onClick={() => props.deleteTask(props.itemId)}>
+                  <FontAwesomeIcon icon={faTrash} />
+                </button>
+              </div>
+            </>
+        )}
+
+      </div>
+  )
+}
+
+export default CreateListTask;

--- a/client/src/pages/CreateList/CreateList.module.scss
+++ b/client/src/pages/CreateList/CreateList.module.scss
@@ -1,0 +1,5 @@
+.titleInput {
+  font-size: 30px;
+  font-weight: bold;
+  text-align: center;
+}

--- a/client/src/pages/CreateList/CreateList.tsx
+++ b/client/src/pages/CreateList/CreateList.tsx
@@ -1,0 +1,106 @@
+import {useRef, useState} from "react";
+import styles from "./CreateList.module.scss"
+import listStyles from "../List/List.module.scss"
+import AddTaskModal from "../../components/List/AddTaskModal.tsx";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPlus } from "@fortawesome/free-solid-svg-icons";
+import CreateListTask from "../../components/List/CreateListTask.tsx";
+import api from "../../services/api.ts";
+import {useNavigate} from "react-router-dom";
+
+interface Task {
+  title: string;
+  completed: boolean;
+}
+
+function CreateList() {
+
+  const navigate = useNavigate();
+
+  const modal = useRef<HTMLDialogElement>(null);
+
+  const [ listName, setListName ] = useState("");
+  const [ tasks, setTasks ] = useState<Task[]>([]);
+
+  function deleteTask(index: number) {
+    // Remove task at index given
+    setTasks(prevTasks =>
+        (prevTasks.filter((_, i) => i !== index))
+    );
+  }
+
+  function toggleTask(index: number) {
+    setTasks(prevTasks =>
+        prevTasks.map((task, i) =>
+            i === index ? { ...task, completed: !task.completed } : task
+        )
+    );
+  }
+
+  function addTask(taskName: string) {
+    setTasks(prevTasks =>
+        [...prevTasks, {title: taskName, completed: false}]
+    );
+    modal.current?.close()
+  }
+
+  function showModal() {
+    modal.current?.showModal()
+  }
+
+  function createList() {
+    api.post(`/api/todolists`, {
+      name: listName,
+      items: tasks
+    })
+    .then((response) => {
+      navigate("/list/" + response.data.id)
+    })
+    .catch(error => {
+      console.error("Failed to create list", error);
+    });
+  }
+
+  return (
+      <>
+        <div className={listStyles.topMenu}>
+          <a href="/home">&lt; Back to All Lists</a>
+        </div>
+
+        <div className={listStyles.listContainer}>
+          <div className={listStyles.header}>
+            <input
+              placeholder="List Name"
+              value = {listName}
+              onChange={e => setListName(e.target.value)}
+              className={styles.titleInput}
+            />
+          </div>
+          <div className={listStyles.listItems}>
+            {tasks.map(((task, index) => (
+                <CreateListTask
+                    key = {index}
+                    itemId= {index}
+                    name = {task.title}
+                    completed={task.completed}
+                    deleteTask={(id) => deleteTask(id)}
+                    toggleTask={(id) => toggleTask(id)}
+                />
+            )))}
+            {tasks.length === 0 && <><h4>No tasks yet!</h4><p>Click "Add a Task" below to create a new task</p></>}
+          </div>
+          <button className={listStyles.addBtn} onClick={showModal}>
+            <FontAwesomeIcon icon={faPlus} className={listStyles.iconSpacing} />
+            Add a Task
+          </button>
+          <button className={listStyles.addBtn} onClick={createList}>
+            <FontAwesomeIcon icon={faPlus} className={listStyles.iconSpacing} />
+            Create List
+          </button>
+        </div>
+        <AddTaskModal ref={modal} addTask={addTask}/>
+      </>
+  )
+}
+
+export default CreateList;


### PR DESCRIPTION
- Added `/create-list` route that takes you to a page to create a new list:

![image](https://github.com/user-attachments/assets/96e23bc0-db5c-496f-9de0-16d52858e7cb )

- Can enter list name:

![image](https://github.com/user-attachments/assets/d22eb1f5-ad41-44f6-8829-15c075f447be)

- Add tasks:

![image](https://github.com/user-attachments/assets/3835155d-ef1c-4e15-a76c-f0c1bb10d6b3)

- Edit tasks:

![image](https://github.com/user-attachments/assets/167d498b-20ec-4e92-9e94-b20e97c0b9cd)

- "Create List" button calls `POST /api/todolists` and then redirects to the new list page

![reditect](https://github.com/user-attachments/assets/1436d0c5-a713-4234-987f-467ce2552ae3)

Code contains duplication so that I could finish this quickly. If needed I can refactor in a following PR
