### PR TITLE
Dockerize server bm

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,10 @@
+# Build the application
+FROM gradle:8.13.0-jdk17 AS build
+COPY . /app
+WORKDIR /app
+RUN ./gradlew build --no-daemon
+
+# Create slim image
+FROM amazoncorretto:17-alpine
+COPY --from=build /app/gradle/wrapper/gradle-wrapper.jar /tmp/app.jar
+ENTRYPOINT [ "java", "-jar", "/tmp/app.jar" ]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,11 +2,11 @@
 FROM gradle:8.13.0-jdk17 AS build
 COPY . /app
 WORKDIR /app
-RUN ./gradlew build --no-daemon
+RUN ./gradlew build --no-daemon -x test
 
 # Create slim image
 FROM amazoncorretto:17-alpine
 WORKDIR /app
 ENV SPRING_PROFILES_ACTIVE=production
 COPY --from=build /app/build/libs/*.jar app.jar
-ENTRYPOINT [ "java", "-jar", "/tmp/app.jar" ]
+ENTRYPOINT [ "java", "-jar", "/app/app.jar" ]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,5 +6,7 @@ RUN ./gradlew build --no-daemon
 
 # Create slim image
 FROM amazoncorretto:17-alpine
-COPY --from=build /app/gradle/wrapper/gradle-wrapper.jar /tmp/app.jar
+WORKDIR /app
+ENV SPRING_PROFILES_ACTIVE=production
+COPY --from=build /app/build/lib/*.jar app.jar
 ENTRYPOINT [ "java", "-jar", "/tmp/app.jar" ]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -8,5 +8,5 @@ RUN ./gradlew build --no-daemon
 FROM amazoncorretto:17-alpine
 WORKDIR /app
 ENV SPRING_PROFILES_ACTIVE=production
-COPY --from=build /app/build/lib/*.jar app.jar
+COPY --from=build /app/build/libs/*.jar app.jar
 ENTRYPOINT [ "java", "-jar", "/tmp/app.jar" ]

--- a/server/src/main/resources/application.properties
+++ b/server/src/main/resources/application.properties
@@ -10,6 +10,7 @@ spring.security.user.password=secret
 # Enable H2 console for web access
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
+spring.h2.console.settings.web-allow-others=true
 
 # Configure H2 to use file mode
 spring.datasource.url=jdbc:h2:file:./data/local_db;AUTO_SERVER=TRUE;DB_CLOSE_DELAY=-1


### PR DESCRIPTION
Currently, with the h2 DB because it is memory only, i'm having trouble building the server with it when i include tests. I've tried to work around it but it just kept giving me trouble. So when we switch to MySQL or find a workaround for the h2 in-memory mode, the server is built skipping the tests. Which is fine for our use case at the moment.