### PR TITLE
Replication: Configure proxy project so that its only job is to forward the request to a current primary

### DIFF
--- a/proxy/README.md
+++ b/proxy/README.md
@@ -5,7 +5,6 @@ This proxy service acts as a gateway for routing API requests from clients to th
 
 ## Features
 - Routes API requests from clients (frontend React project) to the primary backend server.
-- Supports replication to backup servers for write operations (`POST`, `PUT`, `DELETE`).
 - Forwards headers, including authentication tokens, to maintain session status.
 - Dynamically constructs the target URL based on incoming requests.
 
@@ -38,10 +37,7 @@ You can modify `application.properties` to set up the proxy's configuration:
 server.port=8079
 
 # Primary backend (server) URL for local development
-backend.primary.url=http://localhost:8080/api/api
-
-# Backup backend URLs for replication (comma-separated)
-backend.backups.urls=http://backup1:8080/api,http://backup2:8080/api
+backend.primary.url=http://localhost:8081
 ```
 
 ## Project Configuration
@@ -63,6 +59,7 @@ proxy-project
 │   │   │               ├── ProxyApplication.java       # Main application class
 │   │   │               ├── config
 │   │   │               │   └── ProxyConfig.java        # Defines any configuration classes needed (e.g., RestTemplate)
+│   │   │               │   └── ApplicationConfig.java  # Configuration for accessing or updating application properties
 │   │   │               └── controller
 │   │   │                   └── ProxyController.java    # Forwards requests to backend servers
 │   │   └── resources
@@ -91,18 +88,24 @@ A request to the proxy at "http://localhost:8079/api/api/todolists"
 is forwarded to the server at
 "http://localhost:8080/api/api/todolists"
 
+### Update the Primary Server Url
+Updates the url to which the proxy with forward requests.
+```sh
+curl -X POST http://localhost:8079/updatePrimary -H "Content-Type: text/plain" -d "http://localhost:8081" 
+```
+
+### Get the Primary Url
+Gets the current primary server url. This endpoint is primarily for debugging purposes.
+```sh
+curl -X GET "http://localhost:8079/getPrimary"
+```
+
 ## Proxy Logic
 ### Request Forwarding
 - Extracts the full path from the client request.
 - Constructs the appropriate target URL using `backend.primary.url` in `application.properties`.
 - Forwards necessary headers (`Authorization`, `Content-Type`).
 - Forwards the request body.
-
-### Replication for Write Operations
-For `POST`, `PUT`, `DELETE` requests:
-- The primary backend processes the request.
-- The request is also forwarded to all the backup servers for replication.
-- If a backup server fails, an error is logged but does not disrupt the main request.
 
 ## Debugging (optional)
 Enable debug logs in `application.properties`:

--- a/proxy/src/main/java/com/cpsc559/proxy/config/PropertiesConfig.java
+++ b/proxy/src/main/java/com/cpsc559/proxy/config/PropertiesConfig.java
@@ -1,0 +1,18 @@
+package com.cpsc559.proxy.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "backend.primary")
+public class PropertiesConfig {
+    private String url;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+}

--- a/proxy/src/main/java/com/cpsc559/proxy/controller/ProxyController.java
+++ b/proxy/src/main/java/com/cpsc559/proxy/controller/ProxyController.java
@@ -1,30 +1,20 @@
 package com.cpsc559.proxy.controller;
 
+import com.cpsc559.proxy.config.PropertiesConfig;
 import jakarta.servlet.http.HttpServletRequest;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
-
-import java.util.Arrays;
-import java.util.List;
 
 @RestController
 public class ProxyController {
 
     private final WebClient webClient;
+    private final PropertiesConfig propertiesConfig;
 
-    // Base URL for the primary backend server -> defined in application.properties
-    @Value("${backend.primary.url}")
-    private String primaryBackendUrl;
-
-    // List of comma-seperated URLs for the backup servers -> defined in application.properties
-    @Value("${backend.backups.urls}")
-    private String[] backupBackendUrls;
-
-    public ProxyController(WebClient webClient) {
+    public ProxyController(PropertiesConfig propertiesConfig, WebClient webClient) {
+        this.propertiesConfig = propertiesConfig;
         this.webClient = webClient;
     }
 
@@ -35,11 +25,11 @@ public class ProxyController {
         // Added this in case we add a search bar
         String queryString = request.getQueryString();
 
-        // Get the full path after "/api" ex: /todolists, todolist/{id} ...
-        String requestPath = request.getRequestURI().substring("/api".length());
+        // Get the full path ex: /api/todolists, /api/todolist/{id} ...
+        String requestPath = request.getRequestURI();
 
         // Construct the correct path to the primary server
-        String targetUrl = primaryBackendUrl + requestPath +  (queryString != null ? "?" + queryString : "");
+        String targetUrl = propertiesConfig.getUrl() + requestPath +  (queryString != null ? "?" + queryString : "");
 
         // Create HTTP headers to forward necessary headers (e.g., Content-Type, Authorization)
         HttpHeaders headers = new HttpHeaders();
@@ -55,40 +45,26 @@ public class ProxyController {
         HttpMethod method = HttpMethod.valueOf(request.getMethod());
 
         // Build the request object and send it
-        Mono<ResponseEntity<String>> primaryResponse = webClient
+        return webClient
                 .method(method)                                                                 // Set HTTP method
                 .uri(targetUrl)                                                                 // Set target URL
                 .headers(httpHeaders -> httpHeaders.addAll(headers))                // Add headers
                 .bodyValue(body != null ? body : "")                                            // Set request body
                 .retrieve()                                                                     // Send request
                 .toEntity(String.class);                                                        // Parse response
-
-        // For write operations, replicate to backup servers (asynchronously)
-        // If write operation, replicate to backups
-        if (method == HttpMethod.POST || method == HttpMethod.PUT || method == HttpMethod.DELETE) {
-            //replicateToBackups(requestPath, queryString, body, headers, method);
-        }
-
-        return primaryResponse;
     }
 
-    // Helper function to replicate the request to all backup servers
-    private void replicateToBackups(String requestPath, String queryString, String body, HttpHeaders headers, HttpMethod method) {
-        List<String> backupUrls = Arrays.asList(backupBackendUrls);
+    // POST /updatePrimary - update which server to point to
+    @PostMapping("/updatePrimary")
+    public ResponseEntity<?> register(@RequestBody String primaryUrl) {
+        // Update the primary url
+        propertiesConfig.setUrl(primaryUrl);
+        return ResponseEntity.ok().build();
+    }
 
-        // Flux.fromIterable helps us make these replication requests in parallel, so each request is non-blocking
-        Flux.fromIterable(backupUrls)
-                .flatMap(backup -> {
-                    String backupUrl = backup + requestPath + (queryString != null ? "?" + queryString : "");
-                    return webClient
-                            .method(method)
-                            .uri(backupUrl)
-                            .headers(httpHeaders -> httpHeaders.addAll(headers))
-                            .bodyValue(body != null ? body : "")
-                            .retrieve()
-                            .bodyToMono(String.class)
-                            .doOnError(e -> System.err.println("Error replicating to backup " + backup + ": " + e.getMessage()));
-                })
-                .subscribe(); // Asynchronous execution
+    // GET /updatePrimary - get the current primary server, for debugging purposes
+    @GetMapping("/getPrimary")
+    public ResponseEntity<?> register() {
+        return ResponseEntity.ok(propertiesConfig.getUrl());
     }
 }

--- a/proxy/src/main/resources/application.properties
+++ b/proxy/src/main/resources/application.properties
@@ -4,7 +4,4 @@ spring.application.name=proxy
 server.port=8079
 
 # Initial Primary backend URL (e.g., running on another container or different port)
-backend.primary.url=http://localhost:8081/api
-
-# TODO: Delete these, since proxy will no longer need to know about replicas/backups
-backend.backups.urls=http://spring-replica-2:8080/api,http://spring-replica-3:8080/api
+backend.primary.url=http://localhost:8081


### PR DESCRIPTION
- Removed code related to sending requests to the replicas
- Created a `PropertiesConfig` class for getting and setting the primary server url property
- Added `/updatePrimary` and `/getPrimaryEndpoints`

e.g. 
![image](https://github.com/user-attachments/assets/c31d7438-5a89-4667-a068-6e174b225088)
