### PR TITLE
2 consistency apply updates thread

### DIFF
--- a/server/src/main/java/com/cpsc559/server/message/UpdateMessage.java
+++ b/server/src/main/java/com/cpsc559/server/message/UpdateMessage.java
@@ -1,16 +1,17 @@
 package com.cpsc559.server.message;
 
+import jakarta.servlet.AsyncContext;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.web.util.ContentCachingRequestWrapper;
+
 
 @Getter
 @Setter
 @AllArgsConstructor
 public class UpdateMessage implements Comparable<UpdateMessage> {
     private int timestamp;
-    private ContentCachingRequestWrapper request;
+    private AsyncContext asyncContext;
 
     @Override
     public int compareTo(UpdateMessage updateMessage) {

--- a/server/src/main/java/com/cpsc559/server/security/JwtAuthenticationFilter.java
+++ b/server/src/main/java/com/cpsc559/server/security/JwtAuthenticationFilter.java
@@ -20,14 +20,16 @@ import java.util.Collections;
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
+
     @Autowired
     private JwtUtil jwtUtil;
 
     /**
      * Method that checks if the JWT is valid, and sets it in the app security context.
-     * @param request           object representing HTTP request.
-     * @param response          object representing HTTP response.
-     * @param filterChain       object representing a chain of filters.
+     *
+     * @param request     object representing HTTP request.
+     * @param response    object representing HTTP response.
+     * @param filterChain object representing a chain of filters.
      * @throws ServletException
      * @throws IOException
      */
@@ -56,5 +58,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Important: This override needs to be here otherwise the async dispatch in
+     * {@link com.cpsc559.server.service.ApplyUpdateService} will fail JWT filtering.
+     *
+     * @see com.cpsc559.server.service.ApplyUpdateService for usages of AsyncContext
+     */
+    @Override
+    protected boolean shouldNotFilterAsyncDispatch() {
+        return false;
     }
 }

--- a/server/src/main/java/com/cpsc559/server/service/ApplyUpdateService.java
+++ b/server/src/main/java/com/cpsc559/server/service/ApplyUpdateService.java
@@ -1,0 +1,103 @@
+package com.cpsc559.server.service;
+
+import com.cpsc559.server.message.UpdateMessage;
+import com.cpsc559.server.sync.LogicalClock;
+import com.cpsc559.server.sync.UpdateQueue;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.AsyncEvent;
+import jakarta.servlet.AsyncListener;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+
+@Service
+public class ApplyUpdateService {
+
+    private static final Logger logger = LoggerFactory.getLogger(ApplyUpdateService.class);
+
+    @Autowired
+    private UpdateQueue updateQueue;
+
+    @PostConstruct
+    public void startUpdateProcessor() {
+        Thread processorThread = new Thread(() -> {
+            logger.info("Apply-update thread started with timestamp {}", LogicalClock.getTimestamp());
+
+            while (true) {
+                try {
+                    // Inspect the head of the queue
+                    UpdateMessage updateMessage = updateQueue.peek();
+
+                    if (updateMessage != null) {
+                        int messageTimestamp = updateMessage.getTimestamp();
+                        int nextInSequenceTimestamp = LogicalClock.getTimestamp() + 1;
+
+                        // Check if it is safe to apply the message
+                        if (messageTimestamp == nextInSequenceTimestamp) {
+                            updateQueue.dequeue();
+                            applyUpdate(updateMessage);
+                            LogicalClock.incrementTimestamp();
+                        } else {
+                            // If the head is not the expected message, wait a bit before trying again.
+                            Thread.sleep(50);
+                        }
+                    } else {
+                        // Queue is empty, wait a bit before checking again.
+                        Thread.sleep(50);
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    logger.error("Apply-update thread was interrupted.", e);
+                    break;
+                } catch (Exception e) {
+                    logger.error("Exception in apply-update thread", e);
+                }
+            }
+        });
+        processorThread.setDaemon(true);
+        processorThread.start();
+    }
+
+    private void applyUpdate(UpdateMessage updateMessage) {
+        AsyncContext asyncContext = updateMessage.getAsyncContext();
+        HttpServletRequest request = (HttpServletRequest) asyncContext.getRequest();
+        String targetUri = request.getRequestURI();
+
+        logger.info("Applying update with timestamp {}. Forwarding request to URI: {}", updateMessage.getTimestamp(), targetUri);
+
+        // Attach a listener to log when request completes
+        asyncContext.addListener(new AsyncListener() {
+            @Override
+            public void onComplete(AsyncEvent event) {
+                // No logging needed here
+            }
+
+            @Override
+            public void onTimeout(AsyncEvent event) {
+                logger.error("Async processing timeout for update with timestamp {} at URI: {}", updateMessage.getTimestamp(), targetUri);
+            }
+
+            @Override
+            public void onError(AsyncEvent event) {
+                logger.error("Async processing error for update with timestamp {} at URI: {}", updateMessage.getTimestamp(), targetUri);
+            }
+
+            @Override
+            public void onStartAsync(AsyncEvent event) {
+                // No logging needed here
+            }
+        });
+
+        try {
+            // dispatch the request as normal (send to the appropriate controller method)
+            asyncContext.dispatch(targetUri);
+        } catch (IllegalStateException e) {
+            logger.error("Error forwarding update with timestamp {} to URI: {}. Exception: {}",
+                    updateMessage.getTimestamp(), targetUri, e.getMessage(), e);
+        }
+    }
+}

--- a/server/src/main/java/com/cpsc559/server/sync/LogicalClock.java
+++ b/server/src/main/java/com/cpsc559/server/sync/LogicalClock.java
@@ -15,6 +15,6 @@ public class LogicalClock {
     }
 
     public static synchronized int getAndIncrementTimestamp() {
-        return timestamp++;
+        return ++timestamp;
     }
 }


### PR DESCRIPTION
Implemented the apply-updates thread as a service.
- Makes use of AsyncContext.dispatch(), which allows requests to be dispatched to controllers in an asynchronous way
- Each message just needs its logical timestamp and the AsyncContext
- Most of the other changes are small logical changes or logging additions

Fixed bug that caused infinite initiateElection calls on startup
- Instead of waiting some time and polling that the leaderUrl changes, I subscribe to a promise/signal that indicates a leader message was received.