### PR TITLE
Add Retries to Proxy

### DIFF
--- a/proxy/src/main/java/com/cpsc559/proxy/controller/ProxyController.java
+++ b/proxy/src/main/java/com/cpsc559/proxy/controller/ProxyController.java
@@ -7,8 +7,16 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
 import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
 
+import java.time.Duration;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Controller for proxy endpoints
+ */
 @RestController
 public class ProxyController {
 
@@ -22,7 +30,9 @@ public class ProxyController {
         this.webClient = webClient;
     }
 
-    // All requests go through here
+    /**
+     * All requests go through here. Forwards requests to the primary server.
+     */
     @CrossOrigin(origins = "*", methods = {RequestMethod.GET, RequestMethod.POST, RequestMethod.PUT, RequestMethod.DELETE, RequestMethod.OPTIONS})
     @RequestMapping("/**")
     public Mono<ResponseEntity<String>> proxyRequest(HttpServletRequest request, @RequestBody(required = false) String body) {
@@ -31,11 +41,6 @@ public class ProxyController {
 
         // Get the full path ex: /api/todolists, /api/todolist/{id} ...
         String requestPath = request.getRequestURI();
-
-        // Construct the correct path to the primary server
-        String targetUrl = propertiesConfig.getUrl() + requestPath +  (queryString != null ? "?" + queryString : "");
-
-        logger.info("Forwarding request to primary at: {}", targetUrl);
 
         // Create HTTP headers to forward necessary headers (e.g., Content-Type, Authorization)
         HttpHeaders headers = new HttpHeaders();
@@ -50,26 +55,47 @@ public class ProxyController {
         // Get the HTTP method from the initial request (GET, PUT, POST, DELETE)
         HttpMethod method = HttpMethod.valueOf(request.getMethod());
 
-        // Build the request object and send it
-        return webClient
-                .method(method)                                                                 // Set HTTP method
-                .uri(targetUrl)                                                                 // Set target URL
-                .headers(httpHeaders -> httpHeaders.addAll(headers))                // Add headers
-                .bodyValue(body != null ? body : "")                                            // Set request body
-                .retrieve()                                                                     // Send request
-                .toEntity(String.class);                                                        // Parse response
+        return Mono.defer(() -> {
+            // Construct the correct path to the primary server
+            String targetUrl = propertiesConfig.getUrl() + requestPath +  (queryString != null ? "?" + queryString : "");
+            logger.info("Forwarding request to primary at: {}", targetUrl);
+
+            // Build the request object and send it
+            return webClient
+                    .method(method)                                                                 // Set HTTP method
+                    .uri(targetUrl)                                                                 // Set target URL
+                    .headers(httpHeaders -> httpHeaders.addAll(headers))                // Add headers
+                    .bodyValue(body != null ? body : "")                                            // Set request body
+                    .retrieve()                                                                     // Send request
+                    .toEntity(String.class);                                                        // Parse response
+        }).retryWhen(
+            Retry.backoff(5, Duration.ofMillis(500)) // Retry 5 times with exponential backoff
+                    .doBeforeRetry(retrySignal -> logger.warn("Retrying request {} (attempt {} of 5)", requestPath, retrySignal.totalRetries() + 1))
+                    .filter(throwable -> // Only retry on timeouts and connection errors
+                            throwable instanceof TimeoutException
+                            || throwable instanceof WebClientRequestException
+                    )
+                    .onRetryExhaustedThrow((retryBackoffSpec, retrySignal) -> {
+                        logger.info("No server responded after 5 retries, dropping request to {}", requestPath);
+                        throw new RuntimeException("No server responded after 5 retries");
+                    })
+        ).onErrorResume(ignore -> Mono.empty());
     }
 
-    // POST /updatePrimary - update which server to point to
+    /**
+     * POST /updatePrimary - update which server to point to
+     * @param primaryUrl New primary server url to point to
+     */
     @PostMapping("/updatePrimary")
     public ResponseEntity<?> register(@RequestBody String primaryUrl) {
-        // Update the primary url
         logger.info("Updating primary to {}", primaryUrl);
         propertiesConfig.setUrl(primaryUrl);
         return ResponseEntity.ok().build();
     }
 
-    // GET /updatePrimary - get the current primary server, for debugging purposes
+    /**
+     * GET /updatePrimary - get the current primary server, for debugging purposes
+     */
     @GetMapping("/getPrimary")
     public ResponseEntity<?> register() {
         return ResponseEntity.ok(propertiesConfig.getUrl());


### PR DESCRIPTION
Added retries to proxy forwarding requests
On a timeout or connection failure, retries 5 times with exponential backoff starting at 500ms 
After 5 retries the request is dropped

Example logs when all retries fail:
![failedretries](https://github.com/user-attachments/assets/b806195f-f1e9-4f9c-aeae-80db39826b20)


Example logs when a primary fails, the proxy retries, and the request gets sent to the new primary:
![successfulretries](https://github.com/user-attachments/assets/efa8e28e-8d72-468f-b4d3-abbbbd7f31a9)
