### PR TITLE
Added log‑based catch‑up mechanism:

### DIFF
--- a/server/src/main/java/com/cpsc559/server/controller/CatchUpController.java
+++ b/server/src/main/java/com/cpsc559/server/controller/CatchUpController.java
@@ -1,0 +1,45 @@
+package com.cpsc559.server.controller;
+
+import com.cpsc559.server.message.CatchUpMessage;
+import com.cpsc559.server.model.UpdateLog;
+import com.cpsc559.server.repository.UpdateLogRepository;
+import com.cpsc559.server.service.CatchUpService;
+import com.cpsc559.server.sync.LogicalClock;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+// After a successful election, a backup will make an api call to the primary at this route
+// The primary then decides if it needs to "help" the backup catch up or not
+@RestController
+@RequestMapping("/api")
+public class CatchUpController {
+
+    @Autowired
+    private UpdateLogRepository logRepo;
+
+    @Autowired
+    private CatchUpService catchUpService;
+
+    @PostMapping("/catchup")
+    public ResponseEntity<Void> catchUp(@RequestBody CatchUpMessage message) throws JsonProcessingException {
+        // if they’re already up‑to‑date, nothing to do
+        if (message.since >= LogicalClock.getTimestamp()) {
+            return ResponseEntity.ok().build();
+        }
+
+        // get the requests that the backup is missing
+        List<UpdateLog> missing = logRepo.findByTimestampGreaterThanOrderByTimestampAsc(message.since);
+        for (UpdateLog log : missing) {
+            // and replay *each* to the caller server
+            catchUpService.sendToSingleBackup(message.serverUrl, log);
+        }
+        return ResponseEntity.ok().build();
+    }
+}

--- a/server/src/main/java/com/cpsc559/server/controller/ElectionController.java
+++ b/server/src/main/java/com/cpsc559/server/controller/ElectionController.java
@@ -1,12 +1,22 @@
 package com.cpsc559.server.controller;
 
+import com.cpsc559.server.message.BullyMessage;
 import com.cpsc559.server.message.ElectionMessage;
 import com.cpsc559.server.message.LeaderMessage;
-import com.cpsc559.server.message.BullyMessage;
+import com.cpsc559.server.model.UpdateLog;
+import com.cpsc559.server.repository.UpdateLogRepository;
+import com.cpsc559.server.service.CatchUpService;
 import com.cpsc559.server.service.ElectionService;
-import org.springframework.http.ResponseEntity;
+import com.cpsc559.server.sync.LogicalClock;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api")
@@ -15,22 +25,39 @@ public class ElectionController {
     @Autowired
     private ElectionService electionService;
 
+    @Autowired
+    private UpdateLogRepository logRepo;
+
+    @Autowired
+    private CatchUpService catchUpService;
+
     // Case: received message is election message
     @PostMapping("/election")
     public ResponseEntity<?> handleElection(@RequestBody ElectionMessage message) {
-		
-		BullyMessage bullyMessage = electionService.onElectionMessage(message);
-	
-		// The server has to send back a 204 but the client can wait for a 200 response using time out
-		if (bullyMessage != null)
-			return ResponseEntity.ok(bullyMessage);
-		else
-			return ResponseEntity.noContent().build();
+
+        BullyMessage bullyMessage = electionService.onElectionMessage(message);
+
+        // The server has to send back a 204 but the client can wait for a 200 response using time out
+        if (bullyMessage != null)
+            return ResponseEntity.ok(bullyMessage);
+        else
+            return ResponseEntity.noContent().build();
     }
 
     // Case: received message is leader message
     @PostMapping("/leader")
-    public void handleLeader(@RequestBody LeaderMessage message) {
+    public void handleLeader(@RequestBody LeaderMessage message) throws JsonProcessingException {
+
+        // If we are the current leader, and we receive a leader message
+        // the new leader may need to be caught up.
+        // If so, send them their missing requests.
+        if (electionService.isLeader() && message.since < LogicalClock.getTimestamp()) {
+            List<UpdateLog> missing = logRepo.findByTimestampGreaterThanOrderByTimestampAsc(message.since);
+            for (UpdateLog log : missing) {
+                // replay *each* to the caller server
+                catchUpService.sendToSingleBackup(message.getLeaderUrl(), log);
+            }
+        }
         electionService.onLeaderMessage(message);
     }
 }

--- a/server/src/main/java/com/cpsc559/server/message/CatchUpMessage.java
+++ b/server/src/main/java/com/cpsc559/server/message/CatchUpMessage.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class LeaderMessage {
+public class CatchUpMessage {
     public int since;
-    private String leaderUrl;
+    public String serverUrl;
 }

--- a/server/src/main/java/com/cpsc559/server/message/UpdateMessage.java
+++ b/server/src/main/java/com/cpsc559/server/message/UpdateMessage.java
@@ -4,6 +4,7 @@ import jakarta.servlet.AsyncContext;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
 
 
 @Getter
@@ -12,6 +13,7 @@ import lombok.Setter;
 public class UpdateMessage implements Comparable<UpdateMessage> {
     private int timestamp;
     private AsyncContext asyncContext;
+    private final ContentCachingRequestWrapper requestWrapper;
 
     @Override
     public int compareTo(UpdateMessage updateMessage) {

--- a/server/src/main/java/com/cpsc559/server/model/UpdateLog.java
+++ b/server/src/main/java/com/cpsc559/server/model/UpdateLog.java
@@ -1,0 +1,28 @@
+package com.cpsc559.server.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
+@Entity
+public class UpdateLog {
+    @Id
+    private Integer timestamp;
+
+    private String method;
+    private String path;
+
+    @Lob
+    private String headersJson;
+
+    @Lob
+    private String body;
+}

--- a/server/src/main/java/com/cpsc559/server/repository/UpdateLogRepository.java
+++ b/server/src/main/java/com/cpsc559/server/repository/UpdateLogRepository.java
@@ -1,0 +1,14 @@
+package com.cpsc559.server.repository;
+
+import com.cpsc559.server.model.UpdateLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface UpdateLogRepository extends JpaRepository<UpdateLog, Integer> {
+    List<UpdateLog> findByTimestampGreaterThanOrderByTimestampAsc(int ts);
+
+    @Query("select max(u.timestamp) from UpdateLog u")
+    Integer findMaxTimestamp();
+}

--- a/server/src/main/java/com/cpsc559/server/security/SecurityConfig.java
+++ b/server/src/main/java/com/cpsc559/server/security/SecurityConfig.java
@@ -27,7 +27,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable) // Disable CSRF (needed for H2 console)
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable)) // Allow H2 Console to be embedded
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**","/api/election/**", "/api/leader/**", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**", "/error", "/api/health").permitAll()
+                        .requestMatchers("/api/auth/**", "/api/election/**", "/api/leader/**", "/h2-console/**", "/swagger-ui/**", "/v3/api-docs/**", "/error", "/api/health", "/api/catchup/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .formLogin(AbstractHttpConfigurer::disable);

--- a/server/src/main/java/com/cpsc559/server/service/CatchUpService.java
+++ b/server/src/main/java/com/cpsc559/server/service/CatchUpService.java
@@ -1,0 +1,58 @@
+package com.cpsc559.server.service;
+
+import com.cpsc559.server.model.UpdateLog;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+
+// Service that forwards missed requests to the backups
+// It just constructs a request object using the logs, and then sends it to the backup to be handled normally
+@Service
+public class CatchUpService {
+
+    private static final Logger logger = LoggerFactory.getLogger(CatchUpService.class);
+
+    private final WebClient webClient;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    public CatchUpService(WebClient webClient) {
+        this.webClient = webClient;
+    }
+
+    public void sendToSingleBackup(String backupUrl, UpdateLog log) throws JsonProcessingException {
+        Map<String, String> hdrs = objectMapper.readValue(
+                log.getHeadersJson(),
+                new TypeReference<Map<String, String>>() {
+                }
+        );
+
+        HttpHeaders headers = new HttpHeaders();
+        hdrs.forEach(headers::add);
+        headers.add("Update-Timestamp", String.valueOf(log.getTimestamp()));
+        headers.add("X-Catchup", "true");
+
+        logger.info("Sending catch up request to server:{}, with timestamp {}", backupUrl, log.getTimestamp());
+
+        webClient.method(HttpMethod.valueOf(log.getMethod()))
+                .uri(backupUrl + log.getPath())
+                .contentType(MediaType.APPLICATION_JSON)
+                .headers(h -> h.addAll(headers))
+                .body(BodyInserters.fromValue(log.getBody()))
+                .retrieve()
+                .bodyToMono(Void.class)
+                .block();
+    }
+}

--- a/server/src/main/java/com/cpsc559/server/service/UpdateLogService.java
+++ b/server/src/main/java/com/cpsc559/server/service/UpdateLogService.java
@@ -1,0 +1,45 @@
+package com.cpsc559.server.service;
+
+import com.cpsc559.server.model.UpdateLog;
+import com.cpsc559.server.repository.UpdateLogRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+public class UpdateLogService {
+
+    private static final Logger logger = LoggerFactory.getLogger(UpdateLogService.class);
+
+    @Autowired
+    private UpdateLogRepository updateLogRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    public void saveToLog(ContentCachingRequestWrapper request, int timestamp) throws JsonProcessingException {
+        Map<String, String> headers = Collections.list(request.getHeaderNames())
+                .stream().collect(Collectors.toMap(h -> h, request::getHeader));
+        String headersJson = objectMapper.writeValueAsString(headers);
+
+        UpdateLog log = new UpdateLog();
+        log.setTimestamp(timestamp);
+        log.setMethod(request.getMethod());
+        log.setPath(request.getRequestURI());
+        log.setBody(request.getContentAsString());
+        log.setHeadersJson(headersJson);
+
+        String logJson = objectMapper.writeValueAsString(log);
+        logger.info("Saving request to update log: {}", logJson);
+
+        updateLogRepository.save(log);
+    }
+}

--- a/server/src/main/java/com/cpsc559/server/sync/LogicalClock.java
+++ b/server/src/main/java/com/cpsc559/server/sync/LogicalClock.java
@@ -1,10 +1,31 @@
 package com.cpsc559.server.sync;
 
+import com.cpsc559.server.repository.UpdateLogRepository;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class LogicalClock {
-    private static int timestamp = 0;
+    private final UpdateLogRepository logRepo;
+    private static int timestamp;
+    private static final Logger logger = LoggerFactory.getLogger(LogicalClock.class);
+
+    @Autowired
+    public LogicalClock(UpdateLogRepository logRepo) {
+        this.logRepo = logRepo;
+    }
+
+    // Load the last‑seen timestamp from the DB on startup.
+    @PostConstruct
+    private void init() {
+        Integer saved = logRepo.findMaxTimestamp();
+        timestamp = (saved != null ? saved : 0);
+
+        logger.info("Logical clock initialized with timestamp : {}", timestamp);
+    }
 
     public static synchronized int getTimestamp() {
         return timestamp;
@@ -12,9 +33,11 @@ public class LogicalClock {
 
     public static synchronized void incrementTimestamp() {
         timestamp++;
+        logger.info("Logical clock incremented to : {}", timestamp);
     }
 
     public static synchronized int getAndIncrementTimestamp() {
-        return ++timestamp;
+        incrementTimestamp();
+        return timestamp;
     }
 }


### PR DESCRIPTION
### **Logical Clock Persists State:**
- `LogicalClock` Now persists the timestamp after restarting. Read from the `UpdateLogRepository` on startup.

### **Add Saving of all Requests to Database**
- `UpdateLog` JPA entity representing the update log table.

- `UpdateLogRepository` Standard `JpaRepository<UpdateLog, …>` for CRUD and lookups by timestamp.

- `UpdateLogService` Persists each write operation (method, path, headers, body, timestamp) into the log.

### **Added catch‑up API and flow:**

- `CatchUpMessage` DTO with `since` (last applied timestamp) and `serverUrl` (replica endpoint).

- `CatchUpController `(POST `/api/catchup`) Backups call this on the primary after election. Primary loads all `UpdateLog` entries > `since` and replays each via `CatchUpService.sendToSingleBackup()`.

- `CatchUpService` Encapsulates HTTP‐based replay logic to a single backup.

### **Integrated catch‑up into election:**

**Case 1:  The newly joined server becomes the leader**
- **ElectionController.handleLeader** If the current leader receives a leader message, it checks if it’s ahead of the new leader and invokes some catch‑up logic to send missing updates to the new leader.

**Case 2:  The newly joined server does _not_ become the leader**
- **ElectionService.onLeaderMessage** When a non-leader receives a leader message it makes an api call at `/catchup` so that the leader can invoke some catch‑up logic to send missing updates to the new backup.

 Summary of basic flow:
 - All servers (backups + primaries) log all requests they apply in the ``UpdateLogRepository``
 - When a server comes back online, it sets its timestamp from ``UpdateLogRepository``.
 - It then initiates an election.
 - This server either becomes the new leader or it does not become the new leader.
 - If it does not become the new leader, it receives a leader message. Once receiving a leader message, we send an API call at /catchup to the leader. The leader takes care of "replaying" the missed requests.
 - If it does become the new leader, the old leader receives a leader message at /leader. If you are the current leader and you receive a leader message, you then take care of "replaying" any missed requests to the new leader.
 - In both cases the server that has rejoined gets sent "replayed" or "missed" requests.